### PR TITLE
Add support for Kotlin files

### DIFF
--- a/testinggame/__init__.py
+++ b/testinggame/__init__.py
@@ -204,7 +204,7 @@ def _find_git_status(directory, xctestsuperclasses):
     """
     names = {}
     objc_extensions = ['.m', '.mm']
-    java_extensions = ['.java']
+    java_extensions = ['.java', '.kt']
     cpp_extensions = ['.cpp', '.mm']
     python_extensions = ['.py']
     cs_extensions = ['.cs']


### PR DESCRIPTION
This is a really useful project we are using here at Trade Me!

Do you think it would be okay to add support for Kotlin files? These are of extension `*.kt` and the existing code will find `@Test` annotations correctly.